### PR TITLE
feat(users) : service코드 수정 및 createdAt 칼럼삭제

### DIFF
--- a/backend/src/main/java/org/synergym/backend/dto/RoutineDTO.java
+++ b/backend/src/main/java/org/synergym/backend/dto/RoutineDTO.java
@@ -16,7 +16,6 @@ public class RoutineDTO {
     private String name;
     private String routineGoal;
     private Integer userId; // user_id
-    private LocalDateTime createdAt;
     private Boolean useYn;
     private Boolean deleteYn;
 }

--- a/backend/src/main/java/org/synergym/backend/dto/UserDTO.java
+++ b/backend/src/main/java/org/synergym/backend/dto/UserDTO.java
@@ -13,8 +13,8 @@ import java.time.LocalDateTime;
 @Builder
 public class UserDTO {
     private Integer id;
-    private String password;
     private String username;
+    private String password;
     private String role;
     private String email;
     private Integer age;
@@ -22,5 +22,4 @@ public class UserDTO {
     private Float weight;
     private Float height;
     private String fitnessLevel;
-    private LocalDateTime createdAt;
 }

--- a/backend/src/main/java/org/synergym/backend/entity/Exercise.java
+++ b/backend/src/main/java/org/synergym/backend/entity/Exercise.java
@@ -44,18 +44,6 @@ public class Exercise {
     @ElementCollection
     private List<Integer> equipment;
 
-    // DTO로 변환하는 메서드
-    public ExerciseDTO toDTO() {
-        return ExerciseDTO.builder()
-                .id(this.id)
-                .name(this.name)
-                .description(this.description)
-                .category(this.category)
-                .muscles(this.muscles)
-                .equipment(this.equipment)
-                .build();
-    }
-
     // DTO 정보를 Entity에 업데이트하는 메서드
     public void updateFromDTO(ExerciseDTO exerciseDTO) {
         this.name = exerciseDTO.getName();

--- a/backend/src/main/java/org/synergym/backend/entity/LikedExercise.java
+++ b/backend/src/main/java/org/synergym/backend/entity/LikedExercise.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.synergym.backend.dto.LikedExerciseDTO;
 
 @Entity
 @Table(name = "liked_exercises")
@@ -26,13 +25,4 @@ public class LikedExercise {
     @ManyToOne
     @JoinColumn(name = "exerciseId")
     private Exercise exercise;
-
-    // DTO로 변환하는 메서드
-    public LikedExerciseDTO toDTO() {
-        return LikedExerciseDTO.builder()
-                .id(this.id)
-                .userId(this.user.getId())  // User의 ID만 반환
-                .exerciseId(this.exercise.getId())  // Exercise의 ID만 반환
-                .build();
-    }
 }

--- a/backend/src/main/java/org/synergym/backend/entity/Routine.java
+++ b/backend/src/main/java/org/synergym/backend/entity/Routine.java
@@ -5,10 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.CreationTimestamp;
 import org.synergym.backend.dto.RoutineDTO;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "routines")
@@ -28,29 +25,13 @@ public class Routine {
     @JoinColumn(name = "userId")
     private User user;
 
-    @CreationTimestamp
-    private LocalDateTime createdAt;
-
     private Boolean useYn;
     private Boolean deleteYn;
-
-    public RoutineDTO toDTO() {
-        return RoutineDTO.builder()
-                .id(id)
-                .name(name)
-                .routineGoal(routineGoal)
-                .userId(user != null ? user.getId() : null)
-                .createdAt(createdAt)
-                .useYn(useYn)
-                .deleteYn(deleteYn)
-                .build();
-    }
 
     public void updateFromDTO(RoutineDTO dto, User user) {
         this.name = dto.getName();
         this.routineGoal = dto.getRoutineGoal();
         this.user = user;
-        this.createdAt = dto.getCreatedAt();
         this.useYn = dto.getUseYn();
         this.deleteYn = dto.getDeleteYn();
     }

--- a/backend/src/main/java/org/synergym/backend/entity/User.java
+++ b/backend/src/main/java/org/synergym/backend/entity/User.java
@@ -31,37 +31,14 @@ public class User {
     private Float height;
     private String fitnessLevel;
 
-    @CreationTimestamp
-    private LocalDateTime createdAt;
-
-    // DTO로 변환하는 메서드
-    public UserDTO toDTO() {
-        return UserDTO.builder()
-                .id(this.id)
-                .username(this.username)
-                .password(this.password)
-                .role(this.role)
-                .email(this.email)
-                .age(this.age)
-                .gender(this.gender)
-                .weight(this.weight)
-                .height(this.height)
-                .fitnessLevel(this.fitnessLevel)
-                .createdAt(this.createdAt)
-                .build();
-    }
-
-    // DTO 정보를 Entity에 업데이트하는 메서드
-    public void updateFromDTO(UserDTO userDTO) {
-        this.username = userDTO.getUsername();
-        this.password = userDTO.getPassword();
-        this.role = userDTO.getRole();
-        this.email = userDTO.getEmail();
-        this.age = userDTO.getAge();
-        this.gender = userDTO.getGender();
-        this.weight = userDTO.getWeight();
-        this.height = userDTO.getHeight();
-        this.fitnessLevel = userDTO.getFitnessLevel();
-        this.createdAt = userDTO.getCreatedAt();
+    public void updateFromDTO(UserDTO dto) {
+        this.username = dto.getUsername();
+        this.password = dto.getPassword();
+        this.email = dto.getEmail();
+        this.age = dto.getAge();
+        this.gender = dto.getGender();
+        this.weight = dto.getWeight();
+        this.height = dto.getHeight();
+        this.fitnessLevel = dto.getFitnessLevel();
     }
 }

--- a/backend/src/main/java/org/synergym/backend/repository/ExerciseRepository.java
+++ b/backend/src/main/java/org/synergym/backend/repository/ExerciseRepository.java
@@ -3,5 +3,5 @@ package org.synergym.backend.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.synergym.backend.entity.Exercise;
 
-public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
+public interface ExerciseRepository extends JpaRepository<Exercise, Integer> {
 }

--- a/backend/src/main/java/org/synergym/backend/repository/LikedExerciseRepository.java
+++ b/backend/src/main/java/org/synergym/backend/repository/LikedExerciseRepository.java
@@ -8,9 +8,9 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface LikedExerciseRepository extends JpaRepository<LikedExercise, Long> {
+public interface LikedExerciseRepository extends JpaRepository<LikedExercise, Integer> {
     List<LikedExercise> findByUserId(Integer userId);
-    Optional<LikedExercise> findByUserIdAndExerciseId(Integer userId, Long exerciseId);
+    Optional<LikedExercise> findByUserIdAndExerciseId(Integer userId, Integer exerciseId);
 
 }
 

--- a/backend/src/main/java/org/synergym/backend/repository/RoutineRepository.java
+++ b/backend/src/main/java/org/synergym/backend/repository/RoutineRepository.java
@@ -5,7 +5,7 @@ import org.synergym.backend.entity.Routine;
 
 import java.util.List;
 
-public interface RoutineRepository extends JpaRepository<Routine, Long> {
+public interface RoutineRepository extends JpaRepository<Routine, Integer> {
     // 사용자 ID로 루틴 조회
     List<Routine> findByUserId(Long userId);
 }

--- a/backend/src/main/java/org/synergym/backend/repository/UserRepository.java
+++ b/backend/src/main/java/org/synergym/backend/repository/UserRepository.java
@@ -3,6 +3,6 @@ package org.synergym.backend.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.synergym.backend.entity.User;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Integer> {
     User findByUsername(String username);
 }

--- a/backend/src/main/java/org/synergym/backend/service/ExerciseService.java
+++ b/backend/src/main/java/org/synergym/backend/service/ExerciseService.java
@@ -1,13 +1,36 @@
 package org.synergym.backend.service;
 
 import org.synergym.backend.dto.ExerciseDTO;
+import org.synergym.backend.entity.Exercise;
 
 import java.util.List;
 
 public interface ExerciseService {
-    ExerciseDTO getExerciseById(Long id);
-    ExerciseDTO addExercise(ExerciseDTO exerciseDTO);
-    ExerciseDTO updateExercise(Long id, ExerciseDTO exerciseDTO);
-    void deleteExercise(Long id);
+    ExerciseDTO getExerciseById(Integer id);
+    Integer addExercise(ExerciseDTO exerciseDTO);
+    void updateExercise(Integer id, ExerciseDTO exerciseDTO);
+    void deleteExercise(Integer id);
     List<ExerciseDTO> getAllExercises();
+
+    // DTO로 변환하는 메서드
+    default ExerciseDTO entityToDto(Exercise exercise) {
+        return ExerciseDTO.builder()
+                .id(exercise.getId())
+                .name(exercise.getName())
+                .description(exercise.getDescription())
+                .category(exercise.getCategory())
+                .muscles(exercise.getMuscles())
+                .equipment(exercise.getEquipment())
+                .build();
+    }
+
+    default Exercise dtoToEntity(ExerciseDTO dto){
+        return Exercise.builder()
+                .name(dto.getName())
+                .description(dto.getDescription())
+                .category(dto.getCategory())
+                .muscles(dto.getMuscles())
+                .equipment(dto.getEquipment())
+                .build();
+    }
 }

--- a/backend/src/main/java/org/synergym/backend/service/ExerciseServiceImpl.java
+++ b/backend/src/main/java/org/synergym/backend/service/ExerciseServiceImpl.java
@@ -8,6 +8,7 @@ import org.synergym.backend.entity.Exercise;
 import org.synergym.backend.repository.ExerciseRepository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -22,45 +23,30 @@ public class ExerciseServiceImpl implements ExerciseService {
 
     @Transactional
     @Override
-    public ExerciseDTO getExerciseById(Long id) {
-        // Optional을 사용하여 null 체크 및 예외 처리
-        Exercise exercise = exerciseRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Exercise not found"));
-        return exercise.toDTO();  // toDTO 메서드 사용
+    public ExerciseDTO getExerciseById(Integer id) {
+        Optional<Exercise> exercise = exerciseRepository.findById(id);
+        return entityToDto(exercise.get());  // toDTO 메서드 사용
     }
 
     @Transactional
     @Override
-    public ExerciseDTO addExercise(ExerciseDTO exerciseDTO) {
-        Exercise exercise = Exercise.builder()
-                .name(exerciseDTO.getName())
-                .description(exerciseDTO.getDescription())
-                .category(exerciseDTO.getCategory())
-                .muscles(exerciseDTO.getMuscles())
-                .equipment(exerciseDTO.getEquipment())
-                .build();
-
+    public Integer addExercise(ExerciseDTO exerciseDTO) {
+        Exercise exercise = dtoToEntity(exerciseDTO);
         exercise = exerciseRepository.save(exercise);
-        return exercise.toDTO();  // 저장 후 DTO로 반환
+        return exercise.getId();  // 저장 후 DTO로 반환
     }
 
     @Transactional
     @Override
-    public ExerciseDTO updateExercise(Long id, ExerciseDTO exerciseDTO) {
-        // Optional을 사용하여 Exercise 엔티티를 찾고, 없을 경우 예외 처리
-        Exercise exercise = exerciseRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Exercise not found"));
-
-        // DTO 정보를 Entity에 반영
-        exercise.updateFromDTO(exerciseDTO);  // Entity에서 DTO의 정보를 업데이트하는 메서드 호출
-        exercise = exerciseRepository.save(exercise); // 업데이트된 Entity 저장
-
-        return exercise.toDTO();  // DTO 반환
+    public void updateExercise(Integer id, ExerciseDTO exerciseDTO) {
+        Optional<Exercise> exercise = exerciseRepository.findById(id);
+        exercise.get().updateFromDTO(exerciseDTO);  // Entity에서 DTO의 정보를 업데이트하는 메서드 호출
+        exerciseRepository.save(exercise.get()); // 업데이트된 Entity 저장
     }
 
     @Transactional
     @Override
-    public void deleteExercise(Long id) {
+    public void deleteExercise(Integer id) {
         exerciseRepository.deleteById(id);
     }
 
@@ -69,7 +55,7 @@ public class ExerciseServiceImpl implements ExerciseService {
     public List<ExerciseDTO> getAllExercises() {
         return exerciseRepository.findAll()
                 .stream()
-                .map(Exercise::toDTO)  // Entity를 DTO로 변환
+                .map(this::entityToDto)  // Entity를 DTO로 변환
                 .collect(Collectors.toList());
     }
 }

--- a/backend/src/main/java/org/synergym/backend/service/LikedExerciseService.java
+++ b/backend/src/main/java/org/synergym/backend/service/LikedExerciseService.java
@@ -1,11 +1,30 @@
 package org.synergym.backend.service;
 
 import org.synergym.backend.dto.LikedExerciseDTO;
+import org.synergym.backend.entity.Exercise;
+import org.synergym.backend.entity.LikedExercise;
+import org.synergym.backend.entity.User;
 
 import java.util.List;
 
 public interface LikedExerciseService {
-    List<LikedExerciseDTO> getLikedExercisesByUserId(Long userId);
-    void addLikedExercise(Long userId, Long exerciseId);
-    void removeLikedExercise(Long userId, Long exerciseId);
+    List<LikedExerciseDTO> getLikedExercisesByUserId(Integer userId);
+    Integer addLikedExercise(Integer userId, Integer exerciseId);
+    void removeLikedExercise(Integer userId, Integer exerciseId);
+
+    // DTO로 변환하는 메서드
+    default LikedExerciseDTO entityToDto(LikedExercise likedExercise) {
+        return LikedExerciseDTO.builder()
+                .id(likedExercise.getId())
+                .userId(likedExercise.getUser().getId())  // User의 ID만 반환
+                .exerciseId(likedExercise.getExercise().getId())  // Exercise의 ID만 반환
+                .build();
+    }
+
+    default LikedExercise dtoToEntity(User user, Exercise exercise) {
+        return LikedExercise.builder()
+                .user(user)
+                .exercise(exercise)
+                .build();
+    }
 }

--- a/backend/src/main/java/org/synergym/backend/service/RoutineService.java
+++ b/backend/src/main/java/org/synergym/backend/service/RoutineService.java
@@ -1,13 +1,40 @@
 package org.synergym.backend.service;
 
+import org.synergym.backend.dto.LikedExerciseDTO;
 import org.synergym.backend.dto.RoutineDTO;
+import org.synergym.backend.entity.Exercise;
+import org.synergym.backend.entity.LikedExercise;
+import org.synergym.backend.entity.Routine;
+import org.synergym.backend.entity.User;
 
 import java.util.List;
 
 public interface RoutineService {
     RoutineDTO getRoutineById(Integer id);
-    RoutineDTO addRoutine(RoutineDTO routineDTO);
-    RoutineDTO updateRoutine(Integer id, RoutineDTO routineDTO);
+    Integer addRoutine(RoutineDTO routineDTO);
+    void updateRoutine(Integer id, RoutineDTO routineDTO);
     void deleteRoutine(Integer id);
     List<RoutineDTO> getAllRoutines();
+
+    default Routine dtoToEntity(RoutineDTO dto, User user) {
+        return Routine.builder()
+                .id(dto.getId())
+                .name(dto.getName())
+                .routineGoal(dto.getRoutineGoal())
+                .user(user)
+                .useYn(dto.getUseYn())
+                .deleteYn(dto.getDeleteYn())
+                .build();
+    }
+
+    default RoutineDTO entityToDto(Routine routine) {
+        return RoutineDTO.builder()
+                .id(routine.getId())
+                .name(routine.getName())
+                .routineGoal(routine.getRoutineGoal())
+                .userId(routine.getUser() != null ? routine.getUser().getId() : null)
+                .useYn(routine.getUseYn())
+                .deleteYn(routine.getDeleteYn())
+                .build();
+    }
 }

--- a/backend/src/main/java/org/synergym/backend/service/UserService.java
+++ b/backend/src/main/java/org/synergym/backend/service/UserService.java
@@ -1,13 +1,46 @@
 package org.synergym.backend.service;
 
+import org.synergym.backend.dto.RoutineDTO;
 import org.synergym.backend.dto.UserDTO;
+import org.synergym.backend.entity.Routine;
+import org.synergym.backend.entity.User;
 
 import java.util.List;
 
 public interface UserService {
     UserDTO getUserByUsername(String username);
-    UserDTO addUser(UserDTO userDTO);
-    UserDTO updateUser(Long id, UserDTO userDTO);
-    void deleteUser(Long id);
+    Integer addUser(UserDTO userDTO);
+    void updateUser(Integer id, UserDTO userDTO);
+    void deleteUser(Integer id);
     List<UserDTO> getAllUsers();
+
+    default User dtoToEntity(UserDTO dto){
+        return User.builder()
+                .id(dto.getId())
+                .username(dto.getUsername())
+                .password(dto.getPassword())
+                .role(dto.getRole())
+                .email(dto.getEmail())
+                .age(dto.getAge())
+                .gender(dto.getGender())
+                .weight(dto.getWeight())
+                .height(dto.getHeight())
+                .fitnessLevel(dto.getFitnessLevel())
+                .build();
+    }
+
+    default UserDTO entityToDto(User user){
+        return UserDTO.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .password(user.getPassword())
+                .role(user.getRole())
+                .email(user.getEmail())
+                .age(user.getAge())
+                .gender(user.getGender())
+                .weight(user.getWeight())
+                .height(user.getHeight())
+                .fitnessLevel(user.getFitnessLevel())
+                .build();
+    }
 }

--- a/backend/src/main/java/org/synergym/backend/service/UserServiceImpl.java
+++ b/backend/src/main/java/org/synergym/backend/service/UserServiceImpl.java
@@ -27,44 +27,31 @@ public class UserServiceImpl implements UserService {
         if (user == null) {
             throw new RuntimeException("User not found");
         }
-        return user.toDTO();  // toDTO 메서드를 사용
+        return entityToDto(user);  // toDTO 메서드를 사용
     }
 
     @Transactional
     @Override
-    public UserDTO addUser(UserDTO userDTO) {
-        User user = User.builder()
-                .username(userDTO.getUsername())
-                .password(userDTO.getPassword())
-                .role(userDTO.getRole())
-                .email(userDTO.getEmail())
-                .age(userDTO.getAge())
-                .gender(userDTO.getGender())
-                .weight(userDTO.getWeight())
-                .height(userDTO.getHeight())
-                .fitnessLevel(userDTO.getFitnessLevel())
-                .createdAt(userDTO.getCreatedAt())
-                .build();
+    public Integer addUser(UserDTO userDTO) {
+        User user = dtoToEntity(userDTO);
         user = userRepository.save(user);
-        return user.toDTO();  // 저장 후 DTO로 반환
+        return user.getId();  // 저장 후 DTO로 반환
     }
 
     @Transactional
     @Override
-    public UserDTO updateUser(Long id, UserDTO userDTO) {
+    public void updateUser(Integer id, UserDTO userDTO) {
         User user = userRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("User not found"));
 
         // DTO로 받은 정보를 Entity에 반영
         user.updateFromDTO(userDTO);  // Entity에서 DTO의 정보를 업데이트하는 메서드 호출
-        user = userRepository.save(user); // 업데이트된 Entity 저장
-
-        return user.toDTO();  // DTO 반환
+        userRepository.save(user); // 업데이트된 Entity 저장
     }
 
     @Transactional
     @Override
-    public void deleteUser(Long id) {
+    public void deleteUser(Integer id) {
         userRepository.deleteById(id);
     }
 
@@ -73,7 +60,7 @@ public class UserServiceImpl implements UserService {
     public List<UserDTO> getAllUsers() {
         return userRepository.findAll()
                 .stream()
-                .map(User::toDTO)  // Entity를 DTO로 변환
+                .map(this::entityToDto)  // Entity를 DTO로 변환
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
1. service 코드 통일성 있게 수정
entityToDto, dtoToEntity 각 service interface에 추가
리턴타입 수정

2. createdAt 칼럼은 나중에 BaseEntity에서 extends 받을것을 고려하여 삭제